### PR TITLE
switch from default session to session in email factory

### DIFF
--- a/src/main/java/de/vzg/reposis/digibib/email/EmailClientFactory.java
+++ b/src/main/java/de/vzg/reposis/digibib/email/EmailClientFactory.java
@@ -76,7 +76,7 @@ public class EmailClientFactory {
                 }
             };
         }
-        return Session.getDefaultInstance(createSessionPropertiesMap(propertiesMap), authenticator);
+        return Session.getInstance(createSessionPropertiesMap(propertiesMap), authenticator);
     }
 
     private static Properties createSessionPropertiesMap(Map<String, String> propertiesMap) {


### PR DESCRIPTION
Both the `MCRMailer` and the `ContactEmailClient` use `Session#defaultSession`. This causes a problem because the credentials do not match if the client has already been initialized with the other implementation.